### PR TITLE
Minor improvements to an existing PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "base64 0.22.1",
  "bcrypt",
  "config",
  "env_logger",
@@ -661,9 +662,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0.138"
 env_logger = "0.11.8"
 utoipa = { version = "5.3.1", features = ["actix_extras"] }
 utoipa-scalar = { version = "0.3", features = ["actix-web"] }
+base64 = "0.22.1"
 
 [dependencies.uuid]
 version = "1.16.0"

--- a/api/src/bodies.rs
+++ b/api/src/bodies.rs
@@ -1,0 +1,34 @@
+// Deserialize helper functions
+fn _deserialize_filter(
+    filter: &serde_json::Value,
+) -> Result<mongodb::bson::Document, std::io::Error> {
+    match filter {
+        serde_json::Value::Object(_) => {
+            match mongodb::bson::to_document(&filter) {
+                Ok(doc) => return Ok(doc),
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("Invalid filter: {:?}", e),
+                    ));
+                }
+            };
+        }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Filter must be a JSON object",
+        )),
+    }
+}
+
+pub fn parse_filter(filter: &serde_json::Value) -> Result<mongodb::bson::Document, std::io::Error> {
+    _deserialize_filter(filter)
+}
+pub fn parse_optional_filter(
+    filter_opt: &Option<serde_json::Value>,
+) -> Result<mongodb::bson::Document, std::io::Error> {
+    match filter_opt {
+        Some(filter) => _deserialize_filter(filter),
+        None => Ok(mongodb::bson::Document::new()),
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bodies;
 pub mod conf;
 pub mod db;
 pub mod models;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -51,7 +51,7 @@ pub async fn get_db_info(db: web::Data<mongodb::Database>) -> HttpResponse {
         routes::users::post_user,
         routes::users::get_users,
         routes::users::delete_user,
-        routes::objects::get_latest_alert_for_object,
+        routes::objects::get_object,
         routes::catalogs::post_catalog_count_query,
         routes::catalogs::post_catalog_find_query,
         routes::catalogs::post_catalog_cone_search_query,
@@ -80,7 +80,7 @@ async fn main() -> std::io::Result<()> {
             .service(Scalar::with_url("/docs", api_doc.clone()))
             .service(get_health)
             .service(get_db_info)
-            .service(routes::objects::get_latest_alert_for_object)
+            .service(routes::objects::get_object)
             .service(routes::filters::post_filter)
             .service(routes::filters::add_filter_version)
             .service(routes::users::post_user)

--- a/api/src/models/response.rs
+++ b/api/src/models/response.rs
@@ -16,6 +16,13 @@ impl ApiResponseBody {
             data,
         }
     }
+    pub fn not_found(message: &str) -> Self {
+        Self {
+            status: "error".to_string(),
+            message: message.to_string(),
+            data: serde_json::Value::Null,
+        }
+    }
     pub fn internal_error(error_message: &str) -> Self {
         Self {
             status: "error".to_string(),
@@ -35,6 +42,10 @@ impl ApiResponseBody {
 // builds an HttpResponse with an ApiResponseBody
 pub fn ok(message: &str, data: serde_json::Value) -> HttpResponse {
     HttpResponse::Ok().json(ApiResponseBody::ok(message, data))
+}
+
+pub fn not_found(message: &str) -> HttpResponse {
+    HttpResponse::NotFound().json(ApiResponseBody::not_found(message))
 }
 
 pub fn internal_error(message: &str) -> HttpResponse {

--- a/api/src/routes/catalogs.rs
+++ b/api/src/routes/catalogs.rs
@@ -1,4 +1,7 @@
-use crate::models::response;
+use crate::{
+    bodies::{parse_filter, parse_optional_filter},
+    models::response,
+};
 
 use actix_web::{HttpResponse, get, post, web};
 use futures::StreamExt;
@@ -144,7 +147,7 @@ pub async fn post_catalog_count_query(
     web::Json(query): web::Json<CountQuery>,
 ) -> HttpResponse {
     if !catalog_exists(&db, &catalog_name).await {
-        return HttpResponse::NotFound().into();
+        return response::not_found(&format!("Catalog {} does not exist", catalog_name));
     }
     let collection_name = catalog_name.to_string();
     // Get the collection
@@ -179,7 +182,7 @@ pub async fn get_catalog_indexes(
     catalog_name: web::Path<String>,
 ) -> HttpResponse {
     if !catalog_exists(&db, &catalog_name).await {
-        return HttpResponse::NotFound().into();
+        return response::not_found(&format!("Catalog {} does not exist", catalog_name));
     }
     let collection_name = catalog_name.to_string();
     // Get the collection
@@ -228,16 +231,20 @@ pub async fn get_catalog_sample(
     params: web::Query<SampleQuery>,
 ) -> HttpResponse {
     if !catalog_exists(&db, &catalog_name).await {
-        return HttpResponse::NotFound().into();
+        return response::not_found(&format!("Catalog {} does not exist", catalog_name));
     }
     let collection_name = catalog_name.to_string();
     // Get the collection
     let collection = db.collection::<mongodb::bson::Document>(&collection_name);
+
+    let size = params.size.unwrap_or(1) as i32;
+    if size <= 0 || size > 1000 {
+        return response::bad_request("Size must be between 1 and 1000");
+    }
+
     // Get a sample of documents
     match collection
-        .aggregate(vec![
-            doc! { "$sample": { "size": params.size.unwrap_or_default() as i32 } },
-        ])
+        .aggregate(vec![doc! { "$sample": { "size": size } }])
         .await
     {
         Ok(cursor) => {
@@ -283,7 +290,7 @@ impl FindQuery {
 /// Perform a find query on a catalog
 #[utoipa::path(
     post,
-    path = "/catalogs/{catalog_name}/queries/find",
+    path = "/catalogs/{catalog_name}/find",
     params(
         ("catalog_name" = String, Path, description = "Name of the catalog (case insensitive), e.g., 'ztf'")
     ),
@@ -294,20 +301,23 @@ impl FindQuery {
         (status = 500, description = "Internal server error")
     )
 )]
-#[post("/catalogs/{catalog_name}/queries/find")]
+#[post("/catalogs/{catalog_name}/find")]
 pub async fn post_catalog_find_query(
     db: web::Data<Database>,
     catalog_name: web::Path<String>,
     body: web::Json<FindQuery>,
 ) -> HttpResponse {
     if !catalog_exists(&db, &catalog_name).await {
-        return HttpResponse::NotFound().into();
+        return response::not_found(&format!("Catalog {} does not exist", catalog_name));
     }
     let collection_name = catalog_name.to_string();
     // Get the collection
     let collection = db.collection::<mongodb::bson::Document>(&collection_name);
     // Find documents with the provided filter
-    let filter = mongodb::bson::to_document(&body.filter).unwrap();
+    let filter = match parse_filter(&body.filter) {
+        Ok(filter) => filter,
+        Err(e) => return response::bad_request(&format!("Invalid filter: {:?}", e)),
+    };
     let find_options = body.to_find_options();
     match collection.find(filter).with_options(find_options).await {
         Ok(cursor) => {
@@ -366,7 +376,7 @@ impl PartialSchema for Unit {
 
 #[derive(serde::Deserialize, Clone, ToSchema)]
 struct ConeSearchQuery {
-    filter: serde_json::Value,
+    filter: Option<serde_json::Value>,
     projection: Option<serde_json::Value>,
     radius: f64,
     unit: Unit,
@@ -402,7 +412,7 @@ impl ConeSearchQuery {
 /// Perform a cone search query on a catalog
 #[utoipa::path(
     post,
-    path = "/catalogs/{catalog_name}/queries/cone-search",
+    path = "/catalogs/{catalog_name}/cone-search",
     params(
         ("catalog_name" = String, Path, description = "Name of the catalog (case insensitive), e.g., 'ztf'")
     ),
@@ -413,14 +423,14 @@ impl ConeSearchQuery {
         (status = 500, description = "Internal server error")
     )
 )]
-#[post("/catalogs/{catalog_name}/queries/cone-search")]
+#[post("/catalogs/{catalog_name}/cone-search")]
 pub async fn post_catalog_cone_search_query(
     db: web::Data<Database>,
     catalog_name: web::Path<String>,
     body: web::Json<ConeSearchQuery>,
 ) -> HttpResponse {
     if !catalog_exists(&db, &catalog_name).await {
-        return HttpResponse::NotFound().into();
+        return response::not_found(&format!("Catalog {} does not exist", catalog_name));
     }
     let collection_name = catalog_name.to_string();
     // Get the collection
@@ -438,8 +448,11 @@ pub async fn post_catalog_cone_search_query(
     }
     let object_coordinates = &body.object_coordinates;
     let mut docs: HashMap<String, Vec<mongodb::bson::Document>> = HashMap::new();
+    let filter = match parse_optional_filter(&body.filter) {
+        Ok(f) => f,
+        Err(e) => return response::bad_request(&format!("Invalid filter: {:?}", e)),
+    };
     for (object_name, radec) in object_coordinates {
-        let mut filter = mongodb::bson::to_document(&body.filter).unwrap();
         let ra = radec[0] - 180.0;
         let dec = radec[1];
         let center_sphere = doc! {
@@ -448,9 +461,10 @@ pub async fn post_catalog_cone_search_query(
         let geo_within = doc! {
             "$geoWithin": center_sphere
         };
-        filter.insert("coordinates.radec_geojson", geo_within);
+        let mut conesearch_filter = filter.clone();
+        conesearch_filter.insert("coordinates.radec_geojson", geo_within);
         let cursor = match collection
-            .find(filter)
+            .find(conesearch_filter)
             .with_options(find_options.clone())
             .await
         {

--- a/api/src/routes/objects.rs
+++ b/api/src/routes/objects.rs
@@ -1,52 +1,71 @@
 use crate::models::response;
 use actix_web::{HttpResponse, get, web};
+use base64::prelude::*;
 use futures::TryStreamExt;
 use mongodb::{
     Collection, Database,
-    bson::{Document, doc},
+    bson::{Document, doc, document::ValueAccessResult},
 };
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
-struct MostRecentAlert {
+struct Obj {
     object_id: String,
-    alert_metadata: serde_json::Value,
+    candidate: serde_json::Value,
     cutout_science: serde_json::Value,
     cutout_template: serde_json::Value,
     cutout_difference: serde_json::Value,
     prv_candidates: Vec<serde_json::Value>,
+    prv_nondetections: Vec<serde_json::Value>,
+    fp_hists: Vec<serde_json::Value>,
+    classifications: serde_json::Value,
     cross_matches: serde_json::Value,
+    aliases: serde_json::Value,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
-struct MostRecentAlertResponse {
+struct ObjResponse {
     status: String,
     message: String,
-    data: MostRecentAlert,
+    data: Obj,
 }
 
-/// Fetch the most recent alert for a given object in a specified survey
+fn bson_docs_to_json_values(
+    array: ValueAccessResult<&Vec<mongodb::bson::Bson>>,
+) -> Vec<serde_json::Value> {
+    array
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|doc| serde_json::json!(doc.clone()))
+        .collect()
+}
+
+/// Fetch an object from a given survey's alert stream
+/// Ultimately, this endpoint should format the object nicely, in a way that is useful
+/// in a way that is useful for a frontend to display object-level information.
 #[utoipa::path(
     get,
-    path = "/objects/{object_id}/alerts/latest-by-survey/{survey_name}",
+    path = "/alerts/{survey_name}/object/{object_id}",
     params(
-        ("object_id" = String, Path, description = "ID of the object to retrieve"),
         ("survey_name" = String, Path, description = "Name of the survey (e.g., 'ZTF')"),
+        ("object_id" = String, Path, description = "ID of the object to retrieve"),
     ),
     responses(
-        (status = 200, description = "Object found", body = MostRecentAlertResponse),
+        (status = 200, description = "Object found", body = ObjResponse),
         (status = 404, description = "Object not found"),
         (status = 500, description = "Internal server error")
     )
 )]
-#[get("/objects/{object_id}/alerts/latest-by-survey/{survey_name}")]
-pub async fn get_latest_alert_for_object(
+#[get("/alerts/{survey_name}/object/{object_id}")]
+pub async fn get_object(
     db: web::Data<Database>,
     path: web::Path<(String, String)>,
 ) -> HttpResponse {
-    let (object_id, survey_name) = path.into_inner();
-    let survey_name = survey_name.to_uppercase(); // (TEMP) to match with "ZTF"
+    let (survey_name, object_id) = path.into_inner();
+    let survey_name = survey_name.to_uppercase(); // All alert collections are uppercase
     let alerts_collection: Collection<Document> = db.collection(&format!("{}_alerts", survey_name));
+    let cutout_collection: Collection<Document> =
+        db.collection(&format!("{}_alerts_cutouts", survey_name));
     let aux_collection: Collection<Document> =
         db.collection(&format!("{}_alerts_aux", survey_name));
     // Find options for getting most recent alert from alerts collection
@@ -55,11 +74,8 @@ pub async fn get_latest_alert_for_object(
             "candidate.jd": -1,
         })
         .projection(doc! {
-            "_id": 1,
             "candidate": 1,
-            "cutoutScience": 1,
-            "cutoutTemplate": 1,
-            "cutoutDifference": 1,
+            "classifications": 1,
         })
         .limit(1)
         .build();
@@ -67,14 +83,17 @@ pub async fn get_latest_alert_for_object(
     // Get the most recent alert for the object
     let mut alert_cursor = match alerts_collection
         .find(doc! {
-            "objectId": object_id.clone(),
+            "objectId": &object_id,
         })
         .with_options(find_options_recent)
         .await
     {
         Ok(cursor) => cursor,
         Err(error) => {
-            return response::internal_error(&format!("error getting documents: {}", error));
+            return response::internal_error(&format!(
+                "error retrieving latest alert for object {}: {}",
+                object_id, error
+            ));
         }
     };
     let newest_alert = match alert_cursor.try_next().await {
@@ -90,18 +109,43 @@ pub async fn get_latest_alert_for_object(
         }
     };
 
+    // using the candid, query the cutout collection for the cutouts
+    let candid = match newest_alert.get_i64("_id") {
+        Ok(candid) => candid,
+        Err(_) => {
+            return response::ok("no candid found", serde_json::Value::Null);
+        }
+    };
+    let cutouts = match cutout_collection
+        .find_one(doc! {
+            "_id": candid,
+        })
+        .await
+    {
+        Ok(Some(cutouts)) => cutouts,
+        Ok(None) => {
+            return response::ok("no cutouts found", serde_json::Value::Null);
+        }
+        Err(error) => {
+            return response::internal_error(&format!("error getting documents: {}", error));
+        }
+    };
+
     let find_options_aux = mongodb::options::FindOneOptions::builder()
         .projection(doc! {
             "_id": 0,
             "prv_candidates": 1,
+            "prv_nondetections": 1,
+            "fp_hists": 1,
             "cross_matches": 1,
+            "aliases": 1,
         })
         .build();
 
     // Get crossmatches and light curve data from aux collection
     let aux_entry = match aux_collection
         .find_one(doc! {
-            "_id": object_id.clone(),
+            "_id": &object_id,
         })
         .with_options(find_options_aux)
         .await
@@ -119,35 +163,45 @@ pub async fn get_latest_alert_for_object(
 
     // Prepare the response
     // Convert prv_candidates into an array of JSON values
-    let empty_vec = Vec::new();
-    let prv_candidates = aux_entry.get_array("prv_candidates").unwrap_or(&empty_vec);
-    let prv_candidates: Vec<serde_json::Value> = prv_candidates
-        .iter()
-        .map(|doc| serde_json::json!(doc.clone()))
-        .collect();
-    let resp = MostRecentAlert {
+    let prv_candidates = bson_docs_to_json_values(aux_entry.get_array("prv_candidates"));
+    let prv_nondetections = bson_docs_to_json_values(aux_entry.get_array("prv_nondetections"));
+    let fp_hists = bson_docs_to_json_values(aux_entry.get_array("fp_hists"));
+
+    let cutout_science = match cutouts.get_binary_generic("cutoutScience") {
+        Ok(cutout) => cutout,
+        Err(_) => {
+            return response::ok("no cutoutScience found", serde_json::Value::Null);
+        }
+    };
+    let cutout_template = match cutouts.get_binary_generic("cutoutTemplate") {
+        Ok(cutout) => cutout,
+        Err(_) => {
+            return response::ok("no cutoutTemplate found", serde_json::Value::Null);
+        }
+    };
+    let cutout_difference = match cutouts.get_binary_generic("cutoutDifference") {
+        Ok(cutout) => cutout,
+        Err(_) => {
+            return response::ok("no cutoutDifference found", serde_json::Value::Null);
+        }
+    };
+    let resp = Obj {
         object_id: object_id.clone(),
-        alert_metadata: serde_json::json!(newest_alert.get_document("candidate").unwrap().clone()),
-        cutout_science: serde_json::json!(
+        candidate: serde_json::json!(newest_alert.get_document("candidate").unwrap().clone()),
+        cutout_science: serde_json::json!(BASE64_STANDARD.encode(cutout_science)),
+        cutout_template: serde_json::json!(BASE64_STANDARD.encode(cutout_template)),
+        cutout_difference: serde_json::json!(BASE64_STANDARD.encode(cutout_difference)),
+        prv_candidates,
+        prv_nondetections,
+        fp_hists,
+        classifications: serde_json::json!(
             newest_alert
-                .get_document("cutoutScience")
-                .unwrap_or(&doc! {})
+                .get_document("classifications")
+                .unwrap()
                 .clone()
         ),
-        cutout_template: serde_json::json!(
-            newest_alert
-                .get_document("cutoutTemplate")
-                .unwrap_or(&doc! {})
-                .clone()
-        ),
-        cutout_difference: serde_json::json!(
-            newest_alert
-                .get_document("cutoutDifference")
-                .unwrap_or(&doc! {})
-                .clone()
-        ),
-        prv_candidates: prv_candidates,
         cross_matches: serde_json::json!(aux_entry.get_document("cross_matches").unwrap().clone()),
+        aliases: serde_json::json!(aux_entry.get_document("aliases").unwrap().clone()),
     };
     return response::ok(
         &format!("object found with object_id: {}", object_id),


### PR DESCRIPTION
In this PR I:

- edit the "latest alert endpoint" to turn it into an object-level endpoint (it already was but the naming and behavior wasn't super clear to me). Also added missing data products, fixed empty cutouts, deduplicated some code.
- added `src/bodies.rs` which contains methods to parse filter from json bodies (and could contain other methods in the future to parse inputs). Not sure about the location and naming, @petebachant feel free to change that. This is applied to parsing filters (required or optional) in 2 endpoints.
- changed URLs to catalog endpoints to remove 'queries'
- added `not_found` custom responses